### PR TITLE
Text preproc

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+GenreGuesser

--- a/GenreGuesser/julia_text_preproc.py
+++ b/GenreGuesser/julia_text_preproc.py
@@ -1,0 +1,49 @@
+import re
+import string
+string.punctuation
+from nltk.corpus import stopwords
+from nltk.tokenize import word_tokenize
+from nltk.stem import WordNetLemmatizer
+
+def clean_text(text):
+
+    #remove headers like [Chorus] etc
+    headers = re.findall(r"\[(.*?)\]", text)
+    for header in headers:
+        text = text.replace(header, ' ')
+
+    #separate lower/upper case words (like 'needHow')
+    text = re.findall('[A-Z][^A-Z]*', text)
+    text = " ".join(text)
+
+    #remove punctuation
+    exclude = string.punctuation + "’”“"
+    for punctuation in exclude:
+           text = text.replace(punctuation, '')
+
+    #turn text into lowercase
+    text = text.lower()
+
+    #remove numericals
+    text = ''.join(word for word in text if not word.isdigit())
+
+    #remove stopwords
+    stop_words = set(stopwords.words('english'))
+
+    #tokenise
+    word_tokens = word_tokenize(text)
+    text = [w for w in word_tokens if not w in stop_words]
+
+    #lemmatise
+    lemmatizer = WordNetLemmatizer()
+    lemmatized = [lemmatizer.lemmatize(word) for word in text]
+    text = lemmatized
+
+    text = ' '.join(text)
+
+    #rejoin "wan na" to "wanna"
+    wannas = re.findall(r"wan na", text)
+    for wanna in wannas:
+        text = text.replace(wanna, "wanna")
+
+    return text

--- a/notebooks/julia-welch_text_preproc.ipynb
+++ b/notebooks/julia-welch_text_preproc.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/julia-welch_text_preproc.ipynb
+++ b/notebooks/julia-welch_text_preproc.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "19916baa",
+   "id": "e877ad91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,13 +17,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "26f88491",
+   "execution_count": 35,
+   "id": "bc9a674b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exclude = string.punctuation + \"’”“\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "0a072dc7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'!\"#$%&\\'()*+,-./:;<=>?@[\\\\]^_`{|}~’”“'"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "exclude"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "c6e752a2",
    "metadata": {},
    "outputs": [],
    "source": [
     "def clean_text(text):\n",
-    "    for punctuation in string.punctuation:\n",
+    "    for punctuation in exclude:\n",
     "           text = text.replace(punctuation, '')\n",
     "\n",
     "    text = text.lower()\n",
@@ -41,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "9bfeeb12",
+   "id": "c00d01f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,24 +91,135 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "16470165",
+   "execution_count": 55,
+   "id": "12c2e160",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lyrics2 = \"Please save a kid that needs some helpAnd I can’t begin to think of anything that could helpBut the weed is guaranteed, indeed, just what I needHow I feel, upon a time, so recent in time, made me sadWhen I recollect how it used to beLike David and Goliath, kinda like meAnd the Devil tryna rip out my soulTryna catch a nigga on sleep, no-noYou can try again and I’ll be readyWon’t let you kill me in my dream like Freddy KruegerNo, I’m not no loser, I’ll see you in Hell[Chorus]At the end of the day, dayMy mama told me don’t let no one break me, let no one break me(Yeah, yeah, yeah, no)At the end of the day, dayNobody, nobody ever could stop me, ever could stop me(Yeah, yeah, no)At the end of the day, dayYou can’t regret it if you were trying, if you were trying(Yeah, yeah, no)At the end of the day, dayI’m walking with a heart of a lion, yeah”, “[Verse 2]Please save a kid that needs some helpAnd I can’t see ahead of me so I move in stealthHide and seek within a dream I seem to glide above my horrorThough I feel I’ll never be complete inside the dark I borrowTo proceed and remain intact my mental is so unstableAnd they talk and judge a manThey have no clue of what I’m capable’Til I show a side of me no one had thought could be withinI told you, no I’m not a loser, I’ll see you in Hell[Chorus]At the end of the day, dayMy mama told me don’t let no one break me, let no one break me(Yeah, yeah, yeah, no)At the end of the day, dayNobody, nobody ever could stop me, ever could stop me(Yeah, yeah, no)At the end of the day, dayYou can’t regret it if you were trying, if you were trying(Yeah, yeah, no)At the end of the day, dayI’m walking with a heart of a lion, yeah[Bridge]No, no, no, no, no, no, noThe heart of a lion, the heart of a lionYeah, no, yeah (Yeah)No, no, no, no, no, no, noThe heart of a lionYeah, no, yeah (Yeah)No, no, no, no, no, no, noThe heart of a lion, the heart of a lionYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)“, “[Verse 3]I’m just a kid who needs no helpI’ve achieved a bigger thingNo cash or check could be more blessedAnd if you had ever seen the things I’ve seen up in my slumberYou’d be shook, stay awakeNo need to run, your fate would followYou should know, not for the faint at heartThis world understands no cowardIt’s a goal, a simple code, I stay on the grind to the 25th hourAnd I know the fight in me is somewhere hiding deep withinI told you, no, I’ll never let you drag me down to Hell[Chorus]At the end of the day, dayMy mama told me don’t let no one break me, let no one break me(Yeah, yeah, yeah, no)At the end of the day, dayNobody, nobody ever could stop me, ever could stop me(Yeah, yeah, no)At the end of the day, dayYou can’t regret it if you were trying, if you were tryingAt the end of the day, day(Yeah, yeah, no)I’m walking with a heart of a lion, yeah”, ‘[Outro]No, no, no, no, no, no, noYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)Yeah, yeah, yeah...\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26bd6994",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "98fbb79f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lyrics2 = lyrics2.replace(\"[Chorus]\", \"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "ca697558",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lyrics2 = lyrics2.replace(\"[Verse 2]\", \"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "0fc1bb9c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'ooh yeah bad moment well didnt understand ooh yeah harsh left low high heel parking lot always thought id see coming mmbut dont got ta leave engine running front seat mama winter coat dont wan na give dont wan na dont wan na dont wan na well night waking stranger bed dont wan na dont wan na dont wan na give yet'"
+       "'Please save a kid that needs some helpAnd I can’t begin to think of anything that could helpBut the weed is guaranteed, indeed, just what I needHow I feel, upon a time, so recent in time, made me sadWhen I recollect how it used to beLike David and Goliath, kinda like meAnd the Devil tryna rip out my soulTryna catch a nigga on sleep, no-noYou can try again and I’ll be readyWon’t let you kill me in my dream like Freddy KruegerNo, I’m not no loser, I’ll see you in HellAt the end of the day, dayMy mama told me don’t let no one break me, let no one break me(Yeah, yeah, yeah, no)At the end of the day, dayNobody, nobody ever could stop me, ever could stop me(Yeah, yeah, no)At the end of the day, dayYou can’t regret it if you were trying, if you were trying(Yeah, yeah, no)At the end of the day, dayI’m walking with a heart of a lion, yeah”, “Please save a kid that needs some helpAnd I can’t see ahead of me so I move in stealthHide and seek within a dream I seem to glide above my horrorThough I feel I’ll never be complete inside the dark I borrowTo proceed and remain intact my mental is so unstableAnd they talk and judge a manThey have no clue of what I’m capable’Til I show a side of me no one had thought could be withinI told you, no I’m not a loser, I’ll see you in HellAt the end of the day, dayMy mama told me don’t let no one break me, let no one break me(Yeah, yeah, yeah, no)At the end of the day, dayNobody, nobody ever could stop me, ever could stop me(Yeah, yeah, no)At the end of the day, dayYou can’t regret it if you were trying, if you were trying(Yeah, yeah, no)At the end of the day, dayI’m walking with a heart of a lion, yeah[Bridge]No, no, no, no, no, no, noThe heart of a lion, the heart of a lionYeah, no, yeah (Yeah)No, no, no, no, no, no, noThe heart of a lionYeah, no, yeah (Yeah)No, no, no, no, no, no, noThe heart of a lion, the heart of a lionYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)“, “[Verse 3]I’m just a kid who needs no helpI’ve achieved a bigger thingNo cash or check could be more blessedAnd if you had ever seen the things I’ve seen up in my slumberYou’d be shook, stay awakeNo need to run, your fate would followYou should know, not for the faint at heartThis world understands no cowardIt’s a goal, a simple code, I stay on the grind to the 25th hourAnd I know the fight in me is somewhere hiding deep withinI told you, no, I’ll never let you drag me down to HellAt the end of the day, dayMy mama told me don’t let no one break me, let no one break me(Yeah, yeah, yeah, no)At the end of the day, dayNobody, nobody ever could stop me, ever could stop me(Yeah, yeah, no)At the end of the day, dayYou can’t regret it if you were trying, if you were tryingAt the end of the day, day(Yeah, yeah, no)I’m walking with a heart of a lion, yeah”, ‘[Outro]No, no, no, no, no, no, noYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)Yeah, yeah, yeah...'"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "clean_text(lyrics)"
+    "lyrics2"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "ad86fc4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "lyrics2 = re.findall('[A-Z][^A-Z]*', lyrics2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "84c77997",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lyrics2 = \" \".join(lyrics2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "da80f734",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Please save a kid that needs some help And  I can’t begin to think of anything that could help But the weed is guaranteed, indeed, just what  I need How  I feel, upon a time, so recent in time, made me sad When  I recollect how it used to be Like  David and  Goliath, kinda like me And the  Devil tryna rip out my soul Tryna catch a nigga on sleep, no-no You can try again and  I’ll be ready Won’t let you kill me in my dream like  Freddy  Krueger No,  I’m not no loser,  I’ll see you in  Hell At the end of the day, day My mama told me don’t let no one break me, let no one break me( Yeah, yeah, yeah, no) At the end of the day, day Nobody, nobody ever could stop me, ever could stop me( Yeah, yeah, no) At the end of the day, day You can’t regret it if you were trying, if you were trying( Yeah, yeah, no) At the end of the day, day I’m walking with a heart of a lion, yeah”, “ Please save a kid that needs some help And  I can’t see ahead of me so  I move in stealth Hide and seek within a dream  I seem to glide above my horror Though  I feel  I’ll never be complete inside the dark  I borrow To proceed and remain intact my mental is so unstable And they talk and judge a man They have no clue of what  I’m capable’ Til  I show a side of me no one had thought could be within I told you, no  I’m not a loser,  I’ll see you in  Hell At the end of the day, day My mama told me don’t let no one break me, let no one break me( Yeah, yeah, yeah, no) At the end of the day, day Nobody, nobody ever could stop me, ever could stop me( Yeah, yeah, no) At the end of the day, day You can’t regret it if you were trying, if you were trying( Yeah, yeah, no) At the end of the day, day I’m walking with a heart of a lion, yeah[ Bridge] No, no, no, no, no, no, no The heart of a lion, the heart of a lion Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no The heart of a lion Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no The heart of a lion, the heart of a lion Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no Yeah, no, yeah ( Yeah)“, “[ Verse 3] I’m just a kid who needs no help I’ve achieved a bigger thing No cash or check could be more blessed And if you had ever seen the things  I’ve seen up in my slumber You’d be shook, stay awake No need to run, your fate would follow You should know, not for the faint at heart This world understands no coward It’s a goal, a simple code,  I stay on the grind to the 25th hour And  I know the fight in me is somewhere hiding deep within I told you, no,  I’ll never let you drag me down to  Hell At the end of the day, day My mama told me don’t let no one break me, let no one break me( Yeah, yeah, yeah, no) At the end of the day, day Nobody, nobody ever could stop me, ever could stop me( Yeah, yeah, no) At the end of the day, day You can’t regret it if you were trying, if you were trying At the end of the day, day( Yeah, yeah, no) I’m walking with a heart of a lion, yeah”, ‘[ Outro] No, no, no, no, no, no, no Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no Yeah, no, yeah ( Yeah) Yeah, yeah, yeah...'"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lyrics2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "417ef494",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'please save kid need help cant begin think anything could help weed guaranteed indeed need feel upon time recent time made sad recollect used like david goliath kinda like devil tryna rip soul tryna catch nigga sleep nono try ill ready wont let kill dream like freddy krueger im loser ill see hell end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah please save kid need help cant see ahead move stealth hide seek within dream seem glide horror though feel ill never complete inside dark borrow proceed remain intact mental unstable talk judge man clue im capable til show side one thought could within told im loser ill see hell end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah bridge heart lion heart lion yeah yeah yeah heart lion yeah yeah yeah heart lion heart lion yeah yeah yeah yeah yeah yeah verse im kid need help ive achieved bigger thing cash check could blessed ever seen thing ive seen slumber youd shook stay awake need run fate would follow know faint heart world understands coward goal simple code stay grind th hour know fight somewhere hiding deep within told ill never let drag hell end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying end day day yeah yeah im walking heart lion yeah ‘ outro yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah'"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clean_text(lyrics2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "690d266d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/julia-welch_text_preproc.ipynb
+++ b/notebooks/julia-welch_text_preproc.ipynb
@@ -2,11 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "e877ad91",
+   "execution_count": 87,
+   "id": "33eabc96",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import re\n",
     "import string\n",
     "string.punctuation\n",
     "from nltk.corpus import stopwords\n",
@@ -17,51 +18,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "id": "bc9a674b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "exclude = string.punctuation + \"’”“\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "id": "0a072dc7",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'!\"#$%&\\'()*+,-./:;<=>?@[\\\\]^_`{|}~’”“'"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "exclude"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "id": "c6e752a2",
+   "execution_count": 129,
+   "id": "6578e823",
    "metadata": {},
    "outputs": [],
    "source": [
     "def clean_text(text):\n",
+    "    #separate lower/upper case words (like 'needHow')\n",
+    "    text = re.findall('[A-Z][^A-Z]*', text)\n",
+    "    text = \" \".join(text)\n",
+    "    \n",
+    "    #remove headers like [Chorus] etc\n",
+    "    pattern = r\"\\[(.*?)\\]\"\n",
+    "    headers = re.findall(pattern, text)\n",
+    "    for header in headers:\n",
+    "        to_search = text.replace(header, ' ')\n",
+    "    \n",
+    "    #remove punctuation\n",
+    "    exclude = string.punctuation + \"’”“\"\n",
     "    for punctuation in exclude:\n",
     "           text = text.replace(punctuation, '')\n",
-    "\n",
+    "    \n",
+    "    #turn text into lowercase\n",
     "    text = text.lower()\n",
+    "    \n",
+    "    #remove numericals\n",
     "    text = ''.join(word for word in text if not word.isdigit())\n",
+    "    \n",
+    "    #remove stopwords\n",
     "    stop_words = set(stopwords.words('english'))\n",
+    "    \n",
+    "    #tokenise\n",
     "    word_tokens = word_tokenize(text)\n",
     "    text = [w for w in word_tokens if not w in stop_words]\n",
+    "    \n",
+    "    #lemmatise\n",
     "    lemmatizer = WordNetLemmatizer()\n",
     "    lemmatized = [lemmatizer.lemmatize(word) for word in text]\n",
     "    text = lemmatized\n",
@@ -71,28 +62,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "c00d01f8",
+   "execution_count": 131,
+   "id": "8dfb047c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "lyrics = \"Ooh, yeah, you did me so bad When I was in the moment \\\n",
-    "Well, I didn't understand Ooh, yeah, you did me so harsh Left me low with my high heels in the parking lot Always thought I'd see it coming (Mm)But I don't \\\n",
-    "Gotta leave the engine running in the front seat \\\n",
-    "In my mama's winter coat \\\n",
-    "I don't wanna give up on you \\\n",
-    "I don't wanna, don't wanna \\\n",
-    "I don't wanna have to \\\n",
-    "Well, we both have nights \\\n",
-    "Waking up in strangers' beds \\\n",
-    "But I don't wanna, don't wanna \\\n",
+    "lyrics = \"[Verse 1]\\\n",
+    "Ooh, yeah, you did me so bad\\\n",
+    "When I was in the moment\\\n",
+    "Well, I didn't understand\\\n",
+    "Ooh, yeah, you did me so harsh\\\n",
+    "Left me low with my high heels in the parking lot\\\n",
+    "\\\n",
+    "[Pre-Chorus]\\\n",
+    "Always thought I'd see it coming (Mm)\\\n",
+    "But I don't\\\n",
+    "Gotta leave the engine running in the front seat\\\n",
+    "In my mama's winter coat\\\n",
+    "\\\n",
+    "[Chorus]\\\n",
+    "I don't wanna give up on you\\\n",
+    "I don't wanna, don't wanna\\\n",
+    "I don't wanna have to\\\n",
+    "Well, we both have nights\\\n",
+    "Waking up in strangers' beds\\\n",
+    "But I don't wanna, don't wanna\\\n",
+    "I don't wanna give up yet\\\n",
+    "\\\n",
+    "[Verse 2]\\\n",
+    "Ooh, yeah, it's still early days\\\n",
+    "Don't know what I mean to you\\\n",
+    "I don't know what to say\\\n",
+    "Ooh, yeah, don't walk away\\\n",
+    "Don't look at me like that 'cause my mind's 'bout to change\\\n",
+    "[Pre-Chorus]\\\n",
+    "Can't believe that I'm nervous (Mm)\\\n",
+    "Face-to-face\\\n",
+    "All our problems on the surface, is it worth this?\\\n",
+    "I don't think it's too late\\\n",
+    "\\\n",
+    "[Chorus]\\\n",
+    "I don't wanna give up on you\\\n",
+    "I don't wanna, don't wanna\\\n",
+    "I don't wanna have to\\\n",
+    "Well, we both have nights\\\n",
+    "Waking up in strangers' beds\\\n",
+    "But I don't wanna, don't wanna\\\n",
     "I don't wanna give up yet\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
-   "id": "12c2e160",
+   "execution_count": 127,
+   "id": "b3f76f2c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,99 +123,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "26bd6994",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 48,
-   "id": "98fbb79f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lyrics2 = lyrics2.replace(\"[Chorus]\", \"\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "id": "ca697558",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lyrics2 = lyrics2.replace(\"[Verse 2]\", \"\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 50,
-   "id": "0fc1bb9c",
+   "execution_count": 132,
+   "id": "ec8e3a22",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'Please save a kid that needs some helpAnd I can’t begin to think of anything that could helpBut the weed is guaranteed, indeed, just what I needHow I feel, upon a time, so recent in time, made me sadWhen I recollect how it used to beLike David and Goliath, kinda like meAnd the Devil tryna rip out my soulTryna catch a nigga on sleep, no-noYou can try again and I’ll be readyWon’t let you kill me in my dream like Freddy KruegerNo, I’m not no loser, I’ll see you in HellAt the end of the day, dayMy mama told me don’t let no one break me, let no one break me(Yeah, yeah, yeah, no)At the end of the day, dayNobody, nobody ever could stop me, ever could stop me(Yeah, yeah, no)At the end of the day, dayYou can’t regret it if you were trying, if you were trying(Yeah, yeah, no)At the end of the day, dayI’m walking with a heart of a lion, yeah”, “Please save a kid that needs some helpAnd I can’t see ahead of me so I move in stealthHide and seek within a dream I seem to glide above my horrorThough I feel I’ll never be complete inside the dark I borrowTo proceed and remain intact my mental is so unstableAnd they talk and judge a manThey have no clue of what I’m capable’Til I show a side of me no one had thought could be withinI told you, no I’m not a loser, I’ll see you in HellAt the end of the day, dayMy mama told me don’t let no one break me, let no one break me(Yeah, yeah, yeah, no)At the end of the day, dayNobody, nobody ever could stop me, ever could stop me(Yeah, yeah, no)At the end of the day, dayYou can’t regret it if you were trying, if you were trying(Yeah, yeah, no)At the end of the day, dayI’m walking with a heart of a lion, yeah[Bridge]No, no, no, no, no, no, noThe heart of a lion, the heart of a lionYeah, no, yeah (Yeah)No, no, no, no, no, no, noThe heart of a lionYeah, no, yeah (Yeah)No, no, no, no, no, no, noThe heart of a lion, the heart of a lionYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)“, “[Verse 3]I’m just a kid who needs no helpI’ve achieved a bigger thingNo cash or check could be more blessedAnd if you had ever seen the things I’ve seen up in my slumberYou’d be shook, stay awakeNo need to run, your fate would followYou should know, not for the faint at heartThis world understands no cowardIt’s a goal, a simple code, I stay on the grind to the 25th hourAnd I know the fight in me is somewhere hiding deep withinI told you, no, I’ll never let you drag me down to HellAt the end of the day, dayMy mama told me don’t let no one break me, let no one break me(Yeah, yeah, yeah, no)At the end of the day, dayNobody, nobody ever could stop me, ever could stop me(Yeah, yeah, no)At the end of the day, dayYou can’t regret it if you were trying, if you were tryingAt the end of the day, day(Yeah, yeah, no)I’m walking with a heart of a lion, yeah”, ‘[Outro]No, no, no, no, no, no, noYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)No, no, no, no, no, no, noYeah, no, yeah (Yeah)Yeah, yeah, yeah...'"
+       "'verse ooh yeah bad moment well didnt understand ooh yeah harsh left low high heel parking lot pre chorus always thought id see coming mm dont got ta leave engine running front seat mama winter coat chorus dont wan na give dont wan na dont wan na dont wan na well night waking stranger bed dont wan na dont wan na dont wan na give yet verse ooh yeah still early day dont know mean dont know say ooh yeah dont walk away dont look like cause mind bout change pre chorus cant believe im nervous mm facetoface problem surface worth dont think late chorus dont wan na give dont wan na dont wan na dont wan na well night waking stranger bed dont wan na dont wan na dont wan na give yet'"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 132,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "lyrics2"
+    "clean_text(lyrics)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
-   "id": "ad86fc4a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import re\n",
-    "lyrics2 = re.findall('[A-Z][^A-Z]*', lyrics2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 52,
-   "id": "84c77997",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lyrics2 = \" \".join(lyrics2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "id": "da80f734",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Please save a kid that needs some help And  I can’t begin to think of anything that could help But the weed is guaranteed, indeed, just what  I need How  I feel, upon a time, so recent in time, made me sad When  I recollect how it used to be Like  David and  Goliath, kinda like me And the  Devil tryna rip out my soul Tryna catch a nigga on sleep, no-no You can try again and  I’ll be ready Won’t let you kill me in my dream like  Freddy  Krueger No,  I’m not no loser,  I’ll see you in  Hell At the end of the day, day My mama told me don’t let no one break me, let no one break me( Yeah, yeah, yeah, no) At the end of the day, day Nobody, nobody ever could stop me, ever could stop me( Yeah, yeah, no) At the end of the day, day You can’t regret it if you were trying, if you were trying( Yeah, yeah, no) At the end of the day, day I’m walking with a heart of a lion, yeah”, “ Please save a kid that needs some help And  I can’t see ahead of me so  I move in stealth Hide and seek within a dream  I seem to glide above my horror Though  I feel  I’ll never be complete inside the dark  I borrow To proceed and remain intact my mental is so unstable And they talk and judge a man They have no clue of what  I’m capable’ Til  I show a side of me no one had thought could be within I told you, no  I’m not a loser,  I’ll see you in  Hell At the end of the day, day My mama told me don’t let no one break me, let no one break me( Yeah, yeah, yeah, no) At the end of the day, day Nobody, nobody ever could stop me, ever could stop me( Yeah, yeah, no) At the end of the day, day You can’t regret it if you were trying, if you were trying( Yeah, yeah, no) At the end of the day, day I’m walking with a heart of a lion, yeah[ Bridge] No, no, no, no, no, no, no The heart of a lion, the heart of a lion Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no The heart of a lion Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no The heart of a lion, the heart of a lion Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no Yeah, no, yeah ( Yeah)“, “[ Verse 3] I’m just a kid who needs no help I’ve achieved a bigger thing No cash or check could be more blessed And if you had ever seen the things  I’ve seen up in my slumber You’d be shook, stay awake No need to run, your fate would follow You should know, not for the faint at heart This world understands no coward It’s a goal, a simple code,  I stay on the grind to the 25th hour And  I know the fight in me is somewhere hiding deep within I told you, no,  I’ll never let you drag me down to  Hell At the end of the day, day My mama told me don’t let no one break me, let no one break me( Yeah, yeah, yeah, no) At the end of the day, day Nobody, nobody ever could stop me, ever could stop me( Yeah, yeah, no) At the end of the day, day You can’t regret it if you were trying, if you were trying At the end of the day, day( Yeah, yeah, no) I’m walking with a heart of a lion, yeah”, ‘[ Outro] No, no, no, no, no, no, no Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no Yeah, no, yeah ( Yeah) No, no, no, no, no, no, no Yeah, no, yeah ( Yeah) Yeah, yeah, yeah...'"
-      ]
-     },
-     "execution_count": 53,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "lyrics2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
-   "id": "417ef494",
+   "execution_count": 130,
+   "id": "324c6307",
    "metadata": {
     "scrolled": true
    },
@@ -201,10 +153,10 @@
     {
      "data": {
       "text/plain": [
-       "'please save kid need help cant begin think anything could help weed guaranteed indeed need feel upon time recent time made sad recollect used like david goliath kinda like devil tryna rip soul tryna catch nigga sleep nono try ill ready wont let kill dream like freddy krueger im loser ill see hell end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah please save kid need help cant see ahead move stealth hide seek within dream seem glide horror though feel ill never complete inside dark borrow proceed remain intact mental unstable talk judge man clue im capable til show side one thought could within told im loser ill see hell end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah bridge heart lion heart lion yeah yeah yeah heart lion yeah yeah yeah heart lion heart lion yeah yeah yeah yeah yeah yeah verse im kid need help ive achieved bigger thing cash check could blessed ever seen thing ive seen slumber youd shook stay awake need run fate would follow know faint heart world understands coward goal simple code stay grind th hour know fight somewhere hiding deep within told ill never let drag hell end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying end day day yeah yeah im walking heart lion yeah ‘ outro yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah'"
+       "'please save kid need help cant begin think anything could help weed guaranteed indeed need feel upon time recent time made sad recollect used like david goliath kinda like devil tryna rip soul tryna catch nigga sleep nono try ill ready wont let kill dream like freddy krueger im loser ill see hell chorus end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah verse please save kid need help cant see ahead move stealth hide seek within dream seem glide horror though feel ill never complete inside dark borrow proceed remain intact mental unstable talk judge man clue im capable til show side one thought could within told im loser ill see hell chorus end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah bridge heart lion heart lion yeah yeah yeah heart lion yeah yeah yeah heart lion heart lion yeah yeah yeah yeah yeah yeah verse im kid need help ive achieved bigger thing cash check could blessed ever seen thing ive seen slumber youd shook stay awake need run fate would follow know faint heart world understands coward goal simple code stay grind th hour know fight somewhere hiding deep within told ill never let drag hell chorus end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying end day day yeah yeah im walking heart lion yeah ‘ outro yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah'"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,14 +164,6 @@
    "source": [
     "clean_text(lyrics2)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "690d266d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/julia-welch_text_preproc.ipynb
+++ b/notebooks/julia-welch_text_preproc.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 134,
-   "id": "dad76260",
+   "id": "621e2f9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,8 +18,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
-   "id": "54108ada",
+   "execution_count": 167,
+   "id": "0e153d65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,13 +47,10 @@
     "    \n",
     "    #remove stopwords\n",
     "    stop_words = set(stopwords.words('english'))\n",
-    "    print(text)\n",
     "\n",
     "    #tokenise\n",
     "    word_tokens = word_tokenize(text)\n",
     "    text = [w for w in word_tokens if not w in stop_words]\n",
-    "    print(text)\n",
-    "\n",
     "    \n",
     "    #lemmatise\n",
     "    lemmatizer = WordNetLemmatizer()\n",
@@ -65,14 +62,15 @@
     "    #rejoin \"wan na\" to \"wanna\"\n",
     "    wannas = re.findall(r\"wan na\", text)\n",
     "    for wanna in wannas: \n",
-    "        text = text.replace(wanna, )\n",
+    "        text = text.replace(wanna, \"wanna\")\n",
+    "        \n",
     "    return text"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 148,
-   "id": "0c5848ca",
+   "id": "ed2594e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": 154,
-   "id": "582c3045",
+   "id": "9e3494b7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,61 +129,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 165,
-   "id": "b6b671af",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ooh yeah you did me so bad when  i was in the moment well  i didnt understand ooh yeah you did me so harsh left me low with my high heels in the parking lot  always thought  id see it coming  mm but  i dont gotta leave the engine running in the front seat in my mamas winter coat  i dont wanna give up on you i dont wanna dont wanna i dont wanna have to well we both have nights waking up in strangers beds but  i dont wanna dont wanna i dont wanna give up yet  ooh yeah its still early days dont know what  i mean to you i dont know what to say ooh yeah dont walk away dont look at me like that cause my minds bout to change  cant believe that  im nervous  mm facetoface all our problems on the surface is it worth this i dont think its too late  i dont wanna give up on you i dont wanna dont wanna i dont wanna have to well we both have nights waking up in strangers beds but  i dont wanna dont wanna i dont wanna give up yet\n",
-      "['ooh', 'yeah', 'bad', 'moment', 'well', 'didnt', 'understand', 'ooh', 'yeah', 'harsh', 'left', 'low', 'high', 'heels', 'parking', 'lot', 'always', 'thought', 'id', 'see', 'coming', 'mm', 'dont', 'got', 'ta', 'leave', 'engine', 'running', 'front', 'seat', 'mamas', 'winter', 'coat', 'dont', 'wan', 'na', 'give', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'well', 'nights', 'waking', 'strangers', 'beds', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'give', 'yet', 'ooh', 'yeah', 'still', 'early', 'days', 'dont', 'know', 'mean', 'dont', 'know', 'say', 'ooh', 'yeah', 'dont', 'walk', 'away', 'dont', 'look', 'like', 'cause', 'minds', 'bout', 'change', 'cant', 'believe', 'im', 'nervous', 'mm', 'facetoface', 'problems', 'surface', 'worth', 'dont', 'think', 'late', 'dont', 'wan', 'na', 'give', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'well', 'nights', 'waking', 'strangers', 'beds', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'give', 'yet']\n"
-     ]
-    }
-   ],
-   "source": [
-    "test_text = clean_text(lyrics)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 166,
-   "id": "49f03590",
+   "execution_count": 168,
+   "id": "d217baa1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na',\n",
-       " 'wan na']"
+       "'ooh yeah bad moment well didnt understand ooh yeah harsh left low high heel parking lot always thought id see coming mm dont got ta leave engine running front seat mama winter coat dont wanna give dont wanna dont wanna dont wanna well night waking stranger bed dont wanna dont wanna dont wanna give yet ooh yeah still early day dont know mean dont know say ooh yeah dont walk away dont look like cause mind bout change cant believe im nervous mm facetoface problem surface worth dont think late dont wanna give dont wanna dont wanna dont wanna well night waking stranger bed dont wanna dont wanna dont wanna give yet'"
       ]
      },
-     "execution_count": 166,
+     "execution_count": 168,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "re.findall(r\"wan na\", test_text)"
+    "clean_text(lyrics)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 155,
-   "id": "663b1046",
+   "id": "277f6be7",
    "metadata": {
     "scrolled": false
    },

--- a/notebooks/julia-welch_text_preproc.ipynb
+++ b/notebooks/julia-welch_text_preproc.ipynb
@@ -1,6 +1,117 @@
 {
- "cells": [],
- "metadata": {},
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "19916baa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import string\n",
+    "string.punctuation\n",
+    "from nltk.corpus import stopwords\n",
+    "from nltk.tokenize import word_tokenize\n",
+    "import nltk\n",
+    "from nltk.stem import WordNetLemmatizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "26f88491",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clean_text(text):\n",
+    "    for punctuation in string.punctuation:\n",
+    "           text = text.replace(punctuation, '')\n",
+    "\n",
+    "    text = text.lower()\n",
+    "    text = ''.join(word for word in text if not word.isdigit())\n",
+    "    stop_words = set(stopwords.words('english'))\n",
+    "    word_tokens = word_tokenize(text)\n",
+    "    text = [w for w in word_tokens if not w in stop_words]\n",
+    "    lemmatizer = WordNetLemmatizer()\n",
+    "    lemmatized = [lemmatizer.lemmatize(word) for word in text]\n",
+    "    text = lemmatized\n",
+    "    text = ' '.join(text)\n",
+    "    return text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "9bfeeb12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lyrics = \"Ooh, yeah, you did me so bad When I was in the moment \\\n",
+    "Well, I didn't understand Ooh, yeah, you did me so harsh Left me low with my high heels in the parking lot Always thought I'd see it coming (Mm)But I don't \\\n",
+    "Gotta leave the engine running in the front seat \\\n",
+    "In my mama's winter coat \\\n",
+    "I don't wanna give up on you \\\n",
+    "I don't wanna, don't wanna \\\n",
+    "I don't wanna have to \\\n",
+    "Well, we both have nights \\\n",
+    "Waking up in strangers' beds \\\n",
+    "But I don't wanna, don't wanna \\\n",
+    "I don't wanna give up yet\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "16470165",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ooh yeah bad moment well didnt understand ooh yeah harsh left low high heel parking lot always thought id see coming mmbut dont got ta leave engine running front seat mama winter coat dont wan na give dont wan na dont wan na dont wan na well night waking stranger bed dont wan na dont wan na dont wan na give yet'"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clean_text(lyrics)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/notebooks/julia-welch_text_preproc.ipynb
+++ b/notebooks/julia-welch_text_preproc.ipynb
@@ -2,8 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 87,
-   "id": "33eabc96",
+   "execution_count": 134,
+   "id": "dad76260",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,21 +18,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
-   "id": "6578e823",
+   "execution_count": 163,
+   "id": "54108ada",
    "metadata": {},
    "outputs": [],
    "source": [
     "def clean_text(text):\n",
+    "    \n",
+    "    #remove headers like [Chorus] etc\n",
+    "    headers = re.findall(r\"\\[(.*?)\\]\", text)\n",
+    "    for header in headers:\n",
+    "        text = text.replace(header, ' ')\n",
+    "        \n",
     "    #separate lower/upper case words (like 'needHow')\n",
     "    text = re.findall('[A-Z][^A-Z]*', text)\n",
     "    text = \" \".join(text)\n",
-    "    \n",
-    "    #remove headers like [Chorus] etc\n",
-    "    pattern = r\"\\[(.*?)\\]\"\n",
-    "    headers = re.findall(pattern, text)\n",
-    "    for header in headers:\n",
-    "        to_search = text.replace(header, ' ')\n",
     "    \n",
     "    #remove punctuation\n",
     "    exclude = string.punctuation + \"’”“\"\n",
@@ -47,28 +47,36 @@
     "    \n",
     "    #remove stopwords\n",
     "    stop_words = set(stopwords.words('english'))\n",
-    "    \n",
+    "    print(text)\n",
+    "\n",
     "    #tokenise\n",
     "    word_tokens = word_tokenize(text)\n",
     "    text = [w for w in word_tokens if not w in stop_words]\n",
+    "    print(text)\n",
+    "\n",
     "    \n",
     "    #lemmatise\n",
     "    lemmatizer = WordNetLemmatizer()\n",
     "    lemmatized = [lemmatizer.lemmatize(word) for word in text]\n",
     "    text = lemmatized\n",
+    "\n",
     "    text = ' '.join(text)\n",
+    "        \n",
+    "    #rejoin \"wan na\" to \"wanna\"\n",
+    "    wannas = re.findall(r\"wan na\", text)\n",
+    "    for wanna in wannas: \n",
+    "        text = text.replace(wanna, )\n",
     "    return text"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
-   "id": "8dfb047c",
+   "execution_count": 148,
+   "id": "0c5848ca",
    "metadata": {},
    "outputs": [],
    "source": [
-    "lyrics = \"[Verse 1]\\\n",
-    "Ooh, yeah, you did me so bad\\\n",
+    "lyrics = \"[Verse 1] Ooh, yeah, you did me so bad\\\n",
     "When I was in the moment\\\n",
     "Well, I didn't understand\\\n",
     "Ooh, yeah, you did me so harsh\\\n",
@@ -113,8 +121,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
-   "id": "b3f76f2c",
+   "execution_count": 154,
+   "id": "582c3045",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,40 +131,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
-   "id": "ec8e3a22",
+   "execution_count": 165,
+   "id": "b6b671af",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ooh yeah you did me so bad when  i was in the moment well  i didnt understand ooh yeah you did me so harsh left me low with my high heels in the parking lot  always thought  id see it coming  mm but  i dont gotta leave the engine running in the front seat in my mamas winter coat  i dont wanna give up on you i dont wanna dont wanna i dont wanna have to well we both have nights waking up in strangers beds but  i dont wanna dont wanna i dont wanna give up yet  ooh yeah its still early days dont know what  i mean to you i dont know what to say ooh yeah dont walk away dont look at me like that cause my minds bout to change  cant believe that  im nervous  mm facetoface all our problems on the surface is it worth this i dont think its too late  i dont wanna give up on you i dont wanna dont wanna i dont wanna have to well we both have nights waking up in strangers beds but  i dont wanna dont wanna i dont wanna give up yet\n",
+      "['ooh', 'yeah', 'bad', 'moment', 'well', 'didnt', 'understand', 'ooh', 'yeah', 'harsh', 'left', 'low', 'high', 'heels', 'parking', 'lot', 'always', 'thought', 'id', 'see', 'coming', 'mm', 'dont', 'got', 'ta', 'leave', 'engine', 'running', 'front', 'seat', 'mamas', 'winter', 'coat', 'dont', 'wan', 'na', 'give', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'well', 'nights', 'waking', 'strangers', 'beds', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'give', 'yet', 'ooh', 'yeah', 'still', 'early', 'days', 'dont', 'know', 'mean', 'dont', 'know', 'say', 'ooh', 'yeah', 'dont', 'walk', 'away', 'dont', 'look', 'like', 'cause', 'minds', 'bout', 'change', 'cant', 'believe', 'im', 'nervous', 'mm', 'facetoface', 'problems', 'surface', 'worth', 'dont', 'think', 'late', 'dont', 'wan', 'na', 'give', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'well', 'nights', 'waking', 'strangers', 'beds', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'dont', 'wan', 'na', 'give', 'yet']\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_text = clean_text(lyrics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "id": "49f03590",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'verse ooh yeah bad moment well didnt understand ooh yeah harsh left low high heel parking lot pre chorus always thought id see coming mm dont got ta leave engine running front seat mama winter coat chorus dont wan na give dont wan na dont wan na dont wan na well night waking stranger bed dont wan na dont wan na dont wan na give yet verse ooh yeah still early day dont know mean dont know say ooh yeah dont walk away dont look like cause mind bout change pre chorus cant believe im nervous mm facetoface problem surface worth dont think late chorus dont wan na give dont wan na dont wan na dont wan na well night waking stranger bed dont wan na dont wan na dont wan na give yet'"
+       "['wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na',\n",
+       " 'wan na']"
       ]
      },
-     "execution_count": 132,
+     "execution_count": 166,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "clean_text(lyrics)"
+    "re.findall(r\"wan na\", test_text)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
-   "id": "324c6307",
+   "execution_count": 155,
+   "id": "663b1046",
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'please save kid need help cant begin think anything could help weed guaranteed indeed need feel upon time recent time made sad recollect used like david goliath kinda like devil tryna rip soul tryna catch nigga sleep nono try ill ready wont let kill dream like freddy krueger im loser ill see hell chorus end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah verse please save kid need help cant see ahead move stealth hide seek within dream seem glide horror though feel ill never complete inside dark borrow proceed remain intact mental unstable talk judge man clue im capable til show side one thought could within told im loser ill see hell chorus end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah bridge heart lion heart lion yeah yeah yeah heart lion yeah yeah yeah heart lion heart lion yeah yeah yeah yeah yeah yeah verse im kid need help ive achieved bigger thing cash check could blessed ever seen thing ive seen slumber youd shook stay awake need run fate would follow know faint heart world understands coward goal simple code stay grind th hour know fight somewhere hiding deep within told ill never let drag hell chorus end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying end day day yeah yeah im walking heart lion yeah ‘ outro yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah'"
+       "'please save kid need help cant begin think anything could help weed guaranteed indeed need feel upon time recent time made sad recollect used like david goliath kinda like devil tryna rip soul tryna catch nigga sleep nono try ill ready wont let kill dream like freddy krueger im loser ill see hell end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah please save kid need help cant see ahead move stealth hide seek within dream seem glide horror though feel ill never complete inside dark borrow proceed remain intact mental unstable talk judge man clue im capable til show side one thought could within told im loser ill see hell end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying yeah yeah end day day im walking heart lion yeah heart lion heart lion yeah yeah yeah heart lion yeah yeah yeah heart lion heart lion yeah yeah yeah yeah yeah yeah im kid need help ive achieved bigger thing cash check could blessed ever seen thing ive seen slumber youd shook stay awake need run fate would follow know faint heart world understands coward goal simple code stay grind th hour know fight somewhere hiding deep within told ill never let drag hell end day day mama told dont let one break let one break yeah yeah yeah end day day nobody nobody ever could stop ever could stop yeah yeah end day day cant regret trying trying end day day yeah yeah im walking heart lion yeah ‘ yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah yeah'"
       ]
      },
-     "execution_count": 130,
+     "execution_count": 155,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,8 @@ six>=1.14
 joblib
 memoized-property
 termcolor
+
+# nlp
+re
+string
+nltk


### PR DESCRIPTION
Implemented a clean_text function in the notebook and vs code file that takes a string as an argument and will:
- remove headers like [Chorus] etc
- separate lower/upper case words (like 'needHow')
- remove punctuation
- turn text into lowercase
- remove numericals
- remove stopwords
- tokenise
- lemmatise
- rejoin "wan na" to "wanna"
--> the tokeniser splits up "wanna" into "wan" "na" (and "gonna" for example) and might do similar things to other words, we will have to account for this somehow